### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dirtydiesel46/Instagram-Follower-Analyzer/security/code-scanning/2](https://github.com/dirtydiesel46/Instagram-Follower-Analyzer/security/code-scanning/2)

Add an explicit top-level `permissions` block to `.github/workflows/test.yml` so both jobs inherit minimal token access.  
Best fix without changing functionality: add:

- `contents: read` (needed for repository checkout/read)
- `actions: read` (safe/commonly sufficient for using actions metadata)

Since this workflow only runs tests and uploads artifacts (artifact upload does not require repository write scopes like `contents: write`), no write permission appears necessary.

Edit region: immediately after the `on:` trigger block and before `jobs:`.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
